### PR TITLE
Change condition to export record in _export_dependency

### DIFF
--- a/magentoerpconnect/unit/export_synchronizer.py
+++ b/magentoerpconnect/unit/export_synchronizer.py
@@ -305,7 +305,7 @@ class MagentoExporter(MagentoBaseExporter):
             # If wrap is True, relation is already a binding record.
             binding_id = relation.id
 
-        if rel_binder.to_backend(binding_id) is None:
+        if not rel_binder.to_backend(binding_id):
             exporter = self.get_connector_unit_for_model(exporter_class,
                                                          binding_model)
             exporter.run(binding_id)


### PR DESCRIPTION
Change condition so the  `_export_dependency` method export the record when the binding has no magento_id 
=> when  `rel_binder.to_backend` return False.

The previous condition could never pass because we pass the binding id to the method  `to_backend` and not the normal record id. 
